### PR TITLE
add post-workshop watch parties

### DIFF
--- a/Contribute.md
+++ b/Contribute.md
@@ -2,7 +2,7 @@
 
 Any member of the computational science and engineering community who has an interest in improving scientific software teams is encouraged to submit content to build the program of Collegeville 2021.  
 
-While we welcome any relevant contribution to the software teams theme, 
+While we welcome any relevant contribution to the software teams theme,
 
 **_We are particularly interested in contributions that draw from software team experiences, no matter how formal or informal your team processes are.  Often the structures and dynamics of scientific software teams are not clearly documented.  We also are interested in teams that address the software ecosystem, in addition to those that address specific software. We strongly encourage participants to reflect on how their teams are organized and operate, and submit content for the workshop in any of the formats listed below.  By sharing your team's experience, you will help build community awareness about how we can understand and improve scientific software teams._**
 
@@ -16,7 +16,7 @@ We welcome the following contributions:
 | Recorded presentation | June 21 - July 9 | We will accept short recorded presentations on content selected from some of the submitted white papers. If your white paper content would make a good presentation for the workshop, we will contact you to inquire if you are interested in this opportunity. Recorded presentations will be available to attendees before the workshop. |
 | Teatime theme | July 1 |A topic related to software teams for open discussion during teatime. If your teatime theme is accepted, you would facilitate a small group discussion on the theme during the July 20 – 22 workshop. |
 | Poster      |July 1  |A PDF or interactive webpage that will be the focus of small group discussion during teatime. If your poster is accepted, you would facilitate a small group discussion during the July 20 – 22 workshop.   |
-| Watch party | July 12 - 19 | During the week prior to the workshop, participants can host a watch party for one or more of the workshop video recordings. See [this page](WorkshopResources/WatchParty/WatchPartyList.md) for details. |
+| Watch party | July 12 - 19 | During the week prior to the workshop, participants can host a watch party for one or more of the workshop video recordings. Given the increasing number of recorded and available talks online, these watch parties can become regular occasions for sharing recent research and ideas, much like a reading group. More information on the pre-workshop watch parties and their post-workshop sustenance is available on [this page](WorkshopResources/WatchParty/WatchPartyList.md). |
 Panelist |  July 20 - 22 | During the workshop dates of July 20 – 22, we will host a live plenary panel discussion with Q&A as the first event each day.  We are limited to just a few panelists each day and will invite people based on their white paper submission and the diversity of viewpoint for the theme of the day.  We will contact panelist candidates to inquire if you are interested in this opportunity. The panel sessions will be recorded and available after the workshop. |
 
 **All submission will be reviewed by the organizing committee for possible acceptance to the workshop program**

--- a/WorkshopResources/WatchParty/WatchPartyList.md
+++ b/WorkshopResources/WatchParty/WatchPartyList.md
@@ -4,6 +4,8 @@ In order to provide opportunities for attendees to get a head start on workshop 
 
 If you are interested in organizing and hosting a watch party, please add your information in the following table by submitting a pull request.
 
+Are you interested in joining a group that meets to watch and discuss talks like these? Join the CW21 Watch Parties Slack channel to vote on how often you'd like to meet and how new talks should be chosen. 
+
 To edit this page, make a pull request for the [page source on GitHub](https://github.com/Collegeville/CW21/blob/master/WorkshopResources/WatchParty/WatchPartyList.md)
 
 | **Time (US CDT)**| **Date** | **Host(s)** | **Video title(s)** | **Link (Zoom or other)** |

--- a/WorkshopResources/WatchParty/WatchPartyList.md
+++ b/WorkshopResources/WatchParty/WatchPartyList.md
@@ -4,7 +4,7 @@ In order to provide opportunities for attendees to get a head start on workshop 
 
 If you are interested in organizing and hosting a watch party, please add your information in the following table by submitting a pull request.
 
-Are you interested in joining a group that meets to watch and discuss talks like these? Join the CW21 Watch Parties Slack channel to vote on how often you'd like to meet and how new talks should be chosen. 
+Would you like to be part of a group that meets to watch and discuss talks like these? Join the CW21 Watch Parties Slack channel to vote on how often you'd like to meet and how new talks should be chosen. 
 
 To edit this page, make a pull request for the [page source on GitHub](https://github.com/Collegeville/CW21/blob/master/WorkshopResources/WatchParty/WatchPartyList.md)
 


### PR DESCRIPTION
I added a little language to the Contribute and WorkshopResources/WatchParty/WatchPartyList pages that introduce the possibility of regular post-workshop watch parties as an opportunity for continued conversation. 

The changes here aren't complete though—I haven't made the Slack channel mentioned on the WatchPartyList page in case that's not the route that makes the most sense to everyone else. If approved, I'll make the channel on the CW21 Slack and add some explanation and poll questions there. Then I'll add a link to that to the WatchPartyList  page and push those changes to this PR before it's merged.